### PR TITLE
[update] enhance README and improve command-line tool options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,49 +1,84 @@
+# Android String Converter
 
-# Android String Convertor
-
-command-line tool to convert android xml string to arb.
+A command-line tool to convert Android XML string resources to ARB (Application Resource Bundle) files.
 
 ## Usage
 
 ```bash
 dart run bin/android_string_convertor.dart [options] {files/directory}
-
--p, --prefix prefix file name
-(defaults to "app_")
--s, --[no-]sort Sort by key name.
--d, --[no-]directory Path is directory
 ```
 
-### Example
+### Options
 
-This example reads XML string file and convert it to arb file:
+- `-p, --prefix <prefix>`: Prefix for output file name (defaults to "app_")
+- `-s, --[no-]sort`: Sort the output by key name
+- `-d, --[no-]directory`: Input is a directory containing XML files
+- `-o, --output-dir <output-dir>`: Output directory for ARB files (default is same as input directory)
 
-- Single file
+### Examples
 
+**Single file**:
 ```bash
-dart run bin/android_string_convertor.dart  ./example/en.xml
+dart run bin/android_string_convertor.dart ./example/en.xml
 ```
 
-- Multible files
-
+**Multiple files**:
 ```bash
-dart run bin/android_string_convertor.dart  ./example/en.xml ./example/es.xml
+dart run bin/android_string_convertor.dart ./example/en.xml ./example/es.xml
 ```
 
-- Directory
-
+**Directory**:
 ```bash
-dart run bin/android_string_convertor.dart -d ./example 
+dart run bin/android_string_convertor.dart -d ./example
 ```
 
-- With srot the output by key
-
+**Sort output by key**:
 ```bash
 dart run bin/android_string_convertor.dart -s -d ./example
 ```
 
-- With outout prefix filename defaults to app_
-
+**Use custom output prefix**:
 ```bash
 dart run bin/android_string_convertor.dart -p "test_" -d ./example
 ```
+
+**Specify output directory**:
+```bash
+dart run bin/android_string_convertor.dart -d ./example -o ./output
+```
+
+## How it Works
+
+The tool reads Android XML string resource files and converts them to ARB (Application Resource Bundle) files, which are used for localization in Flutter applications.
+
+The main steps are:
+
+1. Parse the input XML file(s) or directory using the `xml` package.
+2. Extract the string resources and their keys from the XML document.
+3. Optionally sort the string resources by key.
+4. Write the string resources to an ARB file in the specified output directory (or the same directory as the input, if not specified).
+
+## Requirements
+
+- Dart SDK 2.19.0 or later
+- `args` and `xml` packages
+
+## Installation
+
+To use the Android String Converter tool, you can run it directly from the command line using the Dart runtime:
+
+```bash
+dart run bin/android_string_convertor.dart [options] {files/directory}
+```
+
+Alternatively, you can build the tool as a standalone executable using the `dart compile` command:
+
+```bash
+dart compile exe bin/android_string_convertor.dart -o android_string_convertor
+```
+
+This will create an `android_string_convertor` executable that you can run directly without the `dart run` prefix.
+
+## Contributing
+
+If you find any issues or have suggestions for improvements, please feel free to open an issue or submit a pull request on the [GitHub repository](https://github.com/OmarMahmoud120/android_string_convertor).

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,43 +5,49 @@ packages:
     dependency: "direct main"
     description:
       name: args
-      url: "https://pub.dartlang.org"
+      sha256: bf9f5caeea8d8fe6721a9c358dd8a5c1947b27f1cfaa18b39c301273594919e6
+      url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.6.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.19.1"
   lints:
     dependency: "direct dev"
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: a2c3d198cb5ea2e179926622d433331d8b58374ab8f29cdda6e863bd62fd369c
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.16.0"
   petitparser:
     dependency: transitive
     description:
       name: petitparser
-      url: "https://pub.dartlang.org"
+      sha256: c15605cd28af66339f8eb6fbe0e541bfe2d1b72d5825efc6598f3e0a31b9ad27
+      url: "https://pub.dev"
     source: hosted
-    version: "4.4.0"
+    version: "6.0.2"
   xml:
     dependency: "direct main"
     description:
       name: xml
-      url: "https://pub.dartlang.org"
+      sha256: b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226
+      url: "https://pub.dev"
     source: hosted
-    version: "5.3.1"
+    version: "6.5.0"
 sdks:
-  dart: ">=2.14.3 <3.0.0"
+  dart: ">=3.4.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,14 +1,14 @@
 name: android_string_convertor
-description:  command-line tool to convert android xml string to arb.
-version: 0.0.1
+description: A command-line tool to convert Android XML string resources to ARB (Application Resource Bundle) files.
+version: 0.0.2
 repository: https://github.com/OmarMahmoud120/android_string_convertor
 
 environment:
   sdk: ">=2.14.3 <3.0.0"
 
 dependencies:
-  args: ^2.3.1
-  xml: ^5.3.1
+  args: ^2.6.0
+  xml: ^6.5.0
 
 dev_dependencies:
   lints: ^1.0.0


### PR DESCRIPTION
This pull request includes updates to the `README.md` and `pubspec.yaml` files to improve documentation and update dependencies. The most important changes are outlined below:

### Documentation Improvements:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1-R84): Improved the description, usage instructions, and examples for the Android String Converter tool. Added sections on how the tool works, requirements, installation, and contributing.

### Dependency Updates:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L2-R11): Updated the `args` package to version `^2.6.0` and the `xml` package to version `^6.5.0`.

### Other Changes:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L2-R11): Updated the version number to `0.0.2` and improved the description to better reflect the tool's functionality.